### PR TITLE
Notes for Powdr patched crypto-bigint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,16 +28,26 @@ rlp = { version = "0.6", optional = true, default-features = false }
 serdect = { version = "0.3", optional = true, default-features = false }
 zeroize = { version = "1", optional = true, default-features = false }
 
+[target.'cfg(all(target_os = "zkvm", target_arch = "riscv32"))'.dependencies]
+getrandom = { version = "0.2", features = ["custom"] }
+powdr-riscv-runtime = { git = "https://github.com/powdr-labs/powdr.git", rev = "5456edb7802dad068ab7bb0eadcad26dd3bd5f14" }
+# powdr-riscv-runtime = { path = "../powdr-8_7_24/powdr/riscv-runtime", features = ["std"] }
+
 [dev-dependencies]
 bincode = "1"
-criterion = { version = "0.5", features = ["html_reports"] }
 hex-literal = "0.4"
 num-bigint = "0.4"
 num-integer = "0.1"
 num-modular = { version = "0.6", features = ["num-bigint", "num-integer", "num-traits"] }
-proptest = "1.5"
-rand_core = { version = "0.6", features = ["std"] }
+rand_core = { version = "0.6", features = ["alloc"] }
 rand_chacha = "0.3"
+
+[target.'cfg(not(all(target_os = "zkvm", target_arch = "riscv32")))'.dev-dependencies]
+criterion = { version = "0.4", features = ["html_reports"] }
+proptest = "1.5"
+
+[target.'cfg(all(target_os = "zkvm", target_arch = "riscv32"))'.dev-dependencies]
+proptest = { version = "1.5", default-features = false, features = ["alloc"] }
 
 [features]
 default = ["rand"]

--- a/powdr_test/.gitignore
+++ b/powdr_test/.gitignore
@@ -1,0 +1,4 @@
+target
+Cargo.lock
+guest/Cargo.lock
+powdr-target

--- a/powdr_test/Cargo.toml
+++ b/powdr_test/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "bigint_test"
+version = "0.1.0"
+edition = "2021"
+
+[features]
+simd = ["powdr/plonky3-simd"]
+
+[dependencies]
+powdr = { git = "https://github.com/powdr-labs/powdr.git", rev = "5456edb7802dad068ab7bb0eadcad26dd3bd5f14", features = ["plonky3"] }
+# powdr = { path = "../powdr-8_7_24/powdr/powdr", features = ["plonky3"] }
+
+serde = { version = "1.0", default-features = false, features = [
+  "alloc",
+  "derive",
+  "rc",
+] }
+serde_cbor = { version = "0.11.2", default-features = false, features = [
+  "alloc",
+] }
+
+env_logger = "0.10.2"
+log = "0.4.17"
+
+[workspace]

--- a/powdr_test/README.md
+++ b/powdr_test/README.md
@@ -1,0 +1,114 @@
+# powdrVM Usage Template
+
+This is a foundational template for generating zero-knowledge proofs with powdrVM.
+You write the code to be proven as a guest program for the zkVM host.
+This template includes a structure for host/guest interaction, ZKP setup,
+and artifact generation.
+
+Guest programs are written in Rust.
+When creating your guest program, you can write Rust code in the usual way,
+including using std and importing packages others have written.
+We provide some additional powdrVM specific functionalities via system calls,
+such as IO operations for host <-> guest communication and precompiles to
+accelerate complex programs via optimized circuits.
+
+## Dependencies
+
+- Rust/cargo
+
+## Usage
+
+This will run the host and generate ZK proofs.
+
+```bash
+cargo run -r
+```
+
+## AVX / Neon
+
+You can enable AVX or Neon support by using the `simd` feature and running
+the host with extra flags:
+
+```bash
+RUSTFLAGS='-C target-cpu=native' cargo run --features simd -r
+```
+
+## Structure
+
+- `src/main.rs`: the host code. This is where you create a powdr `Session`,
+prepare data to be shared with the guest, and run the prover.
+- `guest`: this is the guest crate. It contains the code that will be
+run inside the powdrVM.
+- `powdr-target`: this is where all generated artifacts reside.
+This includes the compiled guest code to powdr-asm, the compiled PIL constraints,
+setup artifacts such as proving and verifying keys, and the final ZK proofs.
+
+## Workflow
+
+Let's look at `src/main.rs` line by line:
+
+Here we create some data we want to share with the guest:
+
+```rust
+let some_data = vec![1, 2, 3, 4, 5];
+```
+
+Create a new powdr session where we'll be running crate `guest` in powdrVM
+and all artifacts will be stored in `powdr-target`:
+
+```rust
+let mut session = Session::builder()
+    .guest_path("./guest")
+    .out_path("powdr-target")
+    .build()
+```
+
+Write `some_data` to channel 1 and the sum of `some_data` to channel 2.
+Note that any `serde` type can be used to share data between host and guest.
+
+The guest will read this data from the channels:
+
+```rust
+    .write(1, &some_data)
+    .write(2, &some_data.iter().sum::<u32>());
+```
+
+The lines below also create a powdr `Session`, but tell powdrVM to use 2^18 rows
+per chunk, instead of the default 2^20. This is useful to decrease memory usage,
+for example, at the expense of proving time.
+
+```rust
+let mut session = Session::builder()
+    .guest_path("./guest")
+    .out_path("powdr-target")
+    .chunk_size_log2(18)
+```
+
+Run the session without generating a proof. Useful for testing the guest code:
+
+```rust
+session.run();
+```
+
+Generate the ZK proof:
+
+```rust
+session.prove();
+```
+
+Before generating a proof, powdrVM has to create the proving and verifying keys (setup)
+for the given guest program.
+When run for the first time, this can take a while.
+Subsequent runs will be faster as the setup only changes if the guest changes.
+
+powdrVM also needs to compute the witnesses for the given execution trace,
+needed by the ZK prover.
+Currently this is done by an automated constraint solver,
+which can be slow for complex programs.
+We are working on a more efficient way to generate witnesses.
+
+You can run the host with INFO logs to have a deeper look at what's happening:
+
+```bash
+RUST_LOG=info cargo run -r
+```

--- a/powdr_test/guest/Cargo.toml
+++ b/powdr_test/guest/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "powdr-guest"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+powdr-riscv-runtime = { git = "https://github.com/powdr-labs/powdr.git", rev = "5456edb7802dad068ab7bb0eadcad26dd3bd5f14", features = ["std"] }
+# powdr-riscv-runtime = { path = "../../powdr-8_7_24/powdr/riscv-runtime", features = ["std"] }
+# crypto-bigint = { git = "https://github.com/powdr-labs/crypto-bigint.git", branch = "powdr" }
+# crypto-bigint = { path = "../../crypto-bigint", features = ["alloc"] } # "alloc" required to enable `multi_exponentiate_montgomery_form_slice()` to be tested; "serde" not enabled as crypto-bigint isn't patched for "serde"
+crypto-bigint = { path = "../../", features = ["alloc"] }
+bincode = "1"
+# serde = { version = "1.0", features = ["derive"] } # "serde" not enabled as crypto-bigint isn't patched for "serde"
+
+[workspace]

--- a/powdr_test/guest/src/main.rs
+++ b/powdr_test/guest/src/main.rs
@@ -1,0 +1,354 @@
+use crypto_bigint::{
+    const_monty_form, impl_modulus,
+    modular::{
+        BoxedMontyForm, BoxedMontyParams, ConstMontyForm, ConstMontyParams, MontyForm, MontyParams,
+    },
+    BoxedUint, Limb, Odd, Uint, U256,
+};
+use crypto_bigint::{powdr, MultiExponentiate};
+use powdr_riscv_runtime;
+use powdr_riscv_runtime::{
+    arith::{modmul_256_u32_le, modmul_256_u8_le},
+    io::read,
+};
+
+fn main() {
+    // In the Powdr zkVM 256-bit numbers are represented in standard form.
+    // Therefore ConstMontyForm type shouldn't convert such numbers to Montgomery form, i.e. (number * R) % modulus.
+    // Instead, it simply calculates number % modulus.
+
+    // ConstMontyForm tests
+    impl_modulus!(
+        Modulus,
+        U256,
+        "ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551"
+    );
+    let values_uint_input = vec![
+        U256::from(105u64),
+        U256::from_be_hex("ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632552"),
+    ];
+    let values_uint_output_expected = vec![U256::from(105u64), U256::from(1u64)];
+
+    // This block indirectly tests `from_integer()` and `new()`, because `const_monty_form!()` uses them.
+    for (i, value_uint) in values_uint_input.iter().enumerate() {
+        let value = const_monty_form!(value_uint, Modulus);
+
+        // Montgomery field should be the standard form in Powdr VM.
+        assert_eq!(
+            value.clone().to_montgomery(),
+            values_uint_output_expected[i]
+        );
+
+        // Retrieved integer should be the standard form in Powdr VM.
+        assert_eq!(value.retrieve(), values_uint_output_expected[i]);
+
+        // Serde tests currently don't pass because there's no way to cast ConstMontyForm<Modulus, LIMBS> to ConstMontyForm<Modulus, 8>.
+        // let value_encoded = bincode::serialize(&value).unwrap();
+        // let value_decoded = bincode::deserialize(&value_encoded).unwrap();
+        // assert_eq!(value, value_decoded);
+
+        // x * x.inv() = 1
+        let inv = value.inv().unwrap();
+        let res = value * inv;
+        assert_eq!(res.retrieve(), U256::ONE);
+
+        // x * x.inv_vartime() = 1
+        let inv_vartime = value.inv_vartime().unwrap();
+        let res_vartime = value * inv_vartime;
+        assert_eq!(res_vartime.retrieve(), U256::ONE);
+    }
+
+    // ((modulus * 2) * 2) mod modulus = 2
+    let a = U256::from_be_hex("ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632552");
+    let b = U256::from(2u64);
+    assert_eq!(
+        (const_monty_form!(a, Modulus) * const_monty_form!(b, Modulus)).retrieve(),
+        U256::from(2u64)
+    );
+
+    // hex(0xffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632552 *
+    // 0xffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632552 %
+    // 0xffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551)
+    // = 1
+    let a = U256::from_be_hex("ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632552");
+    let b = U256::from_be_hex("ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632552");
+    let res = const_monty_form!(a, Modulus) * const_monty_form!(b, Modulus);
+    assert_eq!(res.retrieve(), U256::from(1u64));
+
+    // Test `square()`.
+    let square_res = const_monty_form!(a, Modulus).square();
+    assert_eq!(square_res.retrieve(), U256::from(1u64));
+
+    // a * a.inv() = 1
+    let a = U256::from_be_hex("ff00000000000000000000000000000f00000000000000000000000000000002");
+    let inv = const_monty_form!(a, Modulus).inv().unwrap();
+    powdr_riscv_runtime::print!("inv: {}\n", inv.retrieve());
+    // powdr_riscv_runtime::print!("a * a_inv: {}\n", (const_monty_form!(a, Modulus) * inv).retrieve());
+    assert_eq!((const_monty_form!(a, Modulus) * inv).retrieve(), U256::ONE);
+
+    // Test public constant `ONE`
+    assert_eq!(ConstMontyForm::<Modulus, 8>::ONE.retrieve(), U256::ONE);
+
+    // Test `pow()` and `pow_bounded_exp()`:
+    // Both indirectly use `square_montgomery_form()` and `mul_montgomery_form()`,
+    // which are accelerated by Powdr precompiles.
+    // Test vectors directly taken from crypto-bigint.
+
+    // Taken from `test_powmod()`:
+    impl_modulus!(
+        Modulus_2,
+        U256,
+        "9CC24C5DF431A864188AB905AC751B727C9447A8E99E6366E1AD78A21E8D882B"
+    );
+    let base =
+        U256::from_be_hex("3435D18AA8313EBBE4D20002922225B53F75DC4453BB3EEC0378646F79B524A4");
+    let base_mod = const_monty_form!(base, Modulus_2);
+    let exponent =
+        U256::from_be_hex("77117F1273373C26C700D076B3F780074D03339F56DD0EFB60E7F58441FD3685");
+    let res = base_mod.pow(&exponent);
+    let expected =
+        U256::from_be_hex("3681BC0FEA2E5D394EB178155A127B0FD2EF405486D354251C385BDD51B9D421");
+    assert_eq!(res.retrieve(), expected);
+
+    // Taken from ConstMontyForm test `test_multi_exp_slice()`.
+    // This test uses `multi_exponentiate()`, which indirectly uses `multi_exponentiate_montgomery_form_slice()`,
+    // which is a function Powdr patches.
+    // `multi_exponentiate()` is only ever used by ConstMontyForm.
+    // Note that `multi_exponentiate_montgomery_form_slice()` also requires feature "alloc" enabled,
+    // which is currently enabled for crypto-bigint in our guest Cargo.toml by default.
+    let base2 =
+        U256::from_be_hex("3435D18AA8313EBBE4D20002922225B53F75DC4453BB3EEC0378646F79B524A4");
+    let base2_mod = const_monty_form!(base2, Modulus_2);
+    let exponent2 =
+        U256::from_be_hex("77117F1273373C26C700D076B3F780074D03339F56DD0EFB60E7F58441FD3685");
+    let expected = base_mod.pow(&exponent) * base2_mod.pow(&exponent2);
+    let bases_and_exponents = vec![(base_mod, exponent), (base2_mod, exponent2)];
+    let res = ConstMontyForm::<Modulus_2, { U256::LIMBS }>::multi_exponentiate(
+        bases_and_exponents.as_slice(),
+    );
+    assert_eq!(res, expected);
+
+    // BoxedMontyForm tests
+    let boxed_modulus = BoxedUint::from(U256::from_be_hex(
+        "ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551",
+    ));
+    let boxed_params = BoxedMontyParams::new(boxed_modulus.to_odd().unwrap());
+
+    let values_boxed_uint_input = vec![
+        BoxedUint::from(U256::from(2u64)),
+        BoxedUint::from(U256::from_be_hex(
+            "ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632552",
+        )),
+    ];
+    let values_boxed_uint_output_expected = vec![
+        BoxedUint::from(U256::from(2u64)),
+        BoxedUint::from(U256::from(1u64)),
+    ];
+
+    for (i, val) in values_boxed_uint_input.iter().enumerate() {
+        // Powdr VM patches will only run if both the modulus and the integer have 8 limbs (of 32 bits).
+        assert_eq!(boxed_modulus.nlimbs(), 8);
+        assert_eq!(val.nlimbs(), 8);
+        // `new` and `new_with_arc` are very similar APIs except that the latter takes Arc<BoxedMontyParams>.
+        // Need to test both.
+        let boxed_monty = BoxedMontyForm::new(val.clone(), boxed_params.clone());
+        let boxed_monty_arc_param =
+            BoxedMontyForm::new_with_arc(val.clone(), boxed_params.clone().into());
+
+        // Montgomery field should be the standard form in Powdr VM.
+        assert_eq!(
+            boxed_monty.clone().to_montgomery(),
+            values_boxed_uint_output_expected[i]
+        );
+        assert_eq!(
+            boxed_monty_arc_param.clone().to_montgomery(),
+            values_boxed_uint_output_expected[i]
+        );
+
+        // Retrieved integer should be the standard form in Powdr VM.
+        assert_eq!(boxed_monty.retrieve(), values_boxed_uint_output_expected[i]);
+        assert_eq!(
+            boxed_monty_arc_param.retrieve(),
+            values_boxed_uint_output_expected[i]
+        );
+    }
+
+    // ((modulus * 2) * 2) mod modulus = 2
+    let a = BoxedUint::from(U256::from_be_hex(
+        "ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632552",
+    ));
+    let b = BoxedUint::from(U256::from_be_hex(
+        "0000000000000000000000000000000000000000000000000000000000000002",
+    ));
+    // powdr_riscv_runtime::print!("result boxed {:?}\n", (BoxedMontyForm::new(a, boxed_params.clone()) * BoxedMontyForm::new(b, boxed_params.clone())).retrieve());
+    assert_eq!(
+        (BoxedMontyForm::new(a, boxed_params.clone())
+            * BoxedMontyForm::new(b, boxed_params.clone()))
+        .retrieve(),
+        BoxedUint::from(U256::from(2u64))
+    );
+
+    // hex(0xffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632552 *
+    // 0xffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632552 %
+    // 0xffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551)
+    // = 1
+    let a = BoxedUint::from(U256::from_be_hex(
+        "ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632552",
+    ));
+    let b = BoxedUint::from(U256::from_be_hex(
+        "ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632552",
+    ));
+    let res =
+        BoxedMontyForm::new(a, boxed_params.clone()) * BoxedMontyForm::new(b, boxed_params.clone());
+    assert_eq!(res.retrieve(), BoxedUint::from(U256::from(1u64)));
+
+    // a * a.inv() = 1
+    let a = BoxedUint::from(U256::from_be_hex(
+        "ff00000000000000000000000000000f00000000000000000000000000000002",
+    ));
+    let a_monty = BoxedMontyForm::new(a, boxed_params.clone());
+    let a_monty_inv = a_monty.invert().unwrap(); // uses `inv()`
+    assert_eq!(
+        (a_monty_inv * a_monty.clone()).retrieve(),
+        BoxedUint::from(U256::ONE)
+    );
+
+    // a * a.inv_vartime() = 1
+    let a_monty_inv_vartime = a_monty.invert_vartime().unwrap();
+    assert_eq!(
+        (a_monty_inv_vartime * a_monty).retrieve(),
+        BoxedUint::from(U256::ONE)
+    );
+
+    // Test `one()`.
+    assert_eq!(
+        BoxedMontyForm::one(boxed_params.clone()).to_montgomery(),
+        BoxedUint::from(U256::ONE)
+    );
+
+    // MontyForm tests
+    let monty_mod =
+        U256::from_be_hex("ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551");
+    let monty_param = MontyParams::new(monty_mod.to_odd().unwrap());
+
+    for (i, val) in values_uint_input.iter().enumerate() {
+        let val_monty = MontyForm::new(val, monty_param.clone());
+
+        // Montgomery field should be the standard form in Powdr VM.
+        assert_eq!(val_monty.to_montgomery(), values_uint_output_expected[i]);
+
+        // Retrieved integer should be the standard form in Powdr VM.
+        assert_eq!(val_monty.retrieve(), values_uint_output_expected[i]);
+    }
+
+    // ((modulus * 2) * 2) mod modulus = 2
+    let a = U256::from_be_hex("ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632552");
+    let b = U256::from(2u64);
+    assert_eq!(
+        (MontyForm::new(&a, monty_param.clone()) * MontyForm::new(&b, monty_param.clone()))
+            .retrieve(),
+        U256::from(2u64)
+    );
+
+    // hex(0xffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632552 *
+    // 0xffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632552 %
+    // 0xffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551)
+    // = 1
+    let a = U256::from_be_hex("ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632552");
+    let b = U256::from_be_hex("ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632552");
+    let res = MontyForm::new(&a, monty_param.clone()) * MontyForm::new(&b, monty_param.clone());
+    assert_eq!(res.retrieve(), U256::from(1u64));
+
+    // Test `square()`
+    let res_square = MontyForm::new(&a, monty_param.clone()).square();
+    assert_eq!(res_square.retrieve(), U256::from(1u64));
+
+    // // a * a.inv() = 1
+    let a = U256::from_be_hex("ff00000000000000000000000000000f00000000000000000000000000000002");
+    let inv = MontyForm::new(&a, monty_param.clone()).inv().unwrap();
+    powdr_riscv_runtime::print!("inv: {}\n", inv.retrieve());
+    assert_eq!(
+        (MontyForm::new(&a, monty_param.clone()) * inv).retrieve(),
+        U256::ONE
+    );
+
+    // Test public constant function `one()`
+    assert_eq!(
+        MontyForm::one(monty_param.clone()).to_montgomery(),
+        U256::ONE
+    );
+
+    // Test `pow()` and `pow_bounded_exp()`:
+    // Both indirectly use `square_montgomery_form()` and `mul_montgomery_form()`,
+    // which are accelerated by Powdr precompiles.
+    // Test vectors directly taken from crypto-bigint.
+
+    // Taken from `test_powmod()` from ConstMontyForm:
+    // Additional notes:
+    //    `multi_exponentiate_montgomery_form_array()` is indirectly tested here by `MontyForm::pow()`,
+    //    which calls `MontyForm::pow_bounded_exp()`, which calls `pow_montgomery_form()`,
+    //    which calls `multi_exponentiate_montgomery_form_array()`.
+    let monty_mod =
+        U256::from_be_hex("9CC24C5DF431A864188AB905AC751B727C9447A8E99E6366E1AD78A21E8D882B");
+    let monty_param = MontyParams::new(monty_mod.to_odd().unwrap());
+    let base =
+        U256::from_be_hex("3435D18AA8313EBBE4D20002922225B53F75DC4453BB3EEC0378646F79B524A4");
+    let base_mod = MontyForm::new(&base, monty_param.clone());
+    let exponent =
+        U256::from_be_hex("77117F1273373C26C700D076B3F780074D03339F56DD0EFB60E7F58441FD3685");
+    let res = base_mod.pow(&exponent);
+    let expected =
+        U256::from_be_hex("3681BC0FEA2E5D394EB178155A127B0FD2EF405486D354251C385BDD51B9D421");
+    assert_eq!(res.retrieve(), expected);
+
+    // Uint tests: only tests `mul_mod_special()`, which is not used by any MontyForm types.
+    // Note that `a.mul_mod_special(b, c)` calculates (a * b) % (U256::MAX + 1 - c),
+    // where c can be represented by one limb of 32 bits.
+    // Therefore, the following test does the calculation:
+    // hex(0xffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632552 *
+    // 0xffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551 %
+    // (0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff + 1 - 37))
+    let a = U256::from_be_hex("ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632552");
+    let b = U256::from_be_hex("ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551");
+    let mod_limb = Limb::from(37u32);
+    let res = a.mul_mod_special(&b, mod_limb);
+    assert_eq!(
+        res,
+        U256::from_be_hex("004365D41D819D719A02FC8E5D724AB28A58CF513D90BD29606CC5852441ADEE")
+    );
+
+    // BoxedUint tests:
+    let a = BoxedUint::from(U256::from_be_hex(
+        "ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632552",
+    ));
+    let b = BoxedUint::from(U256::from_be_hex(
+        "ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551",
+    ));
+    let mod_limb = Limb::from(37u32);
+    let res = a.mul_mod_special(&b, mod_limb);
+    assert_eq!(
+        res,
+        BoxedUint::from(U256::from_be_hex(
+            "004365D41D819D719A02FC8E5D724AB28A58CF513D90BD29606CC5852441ADEE"
+        ))
+    );
+
+    // Wrapped Powdr syscall tests
+    let res = powdr::modmul_boxed_uint_256(
+        &BoxedUint::from(U256::from_be_hex(
+            "ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632552",
+        )),
+        &BoxedUint::from(U256::from(2u64)),
+        &BoxedUint::from(U256::from_be_hex(
+            "ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551",
+        )),
+    );
+    assert_eq!(res, BoxedUint::from(U256::from(2u32)));
+
+    let res = powdr::modmul_uint_256(
+        &U256::from_be_hex("ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632552"),
+        &U256::from_be_hex("ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632552"),
+        &U256::from_be_hex("ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551"),
+    );
+    assert_eq!(res, U256::from(1u32));
+}

--- a/powdr_test/rust-toolchain.toml
+++ b/powdr_test/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "nightly-2024-09-21"

--- a/powdr_test/src/main.rs
+++ b/powdr_test/src/main.rs
@@ -1,0 +1,26 @@
+use powdr::{riscv::RuntimeLibs, Session};
+
+fn main() {
+    env_logger::init();
+
+    // Create a new powdr session to make proofs for the `guest` crate.
+    // Store all temporary and final artifacts in `powdr-target`.
+    let mut session = Session::builder()
+        .guest_path("./guest")
+        .out_path("powdr-target")
+        // powdrVM splits long execution traces into chunks
+        // which are proven individually.
+        // The default size of a chunk is 2^20 = 1048576 rows.
+        // For experiments and smaller traces/proofs, it may be beneficial to reduce the chunk size.
+        // Create a new powdr session with a custom chunk size.
+        // 2^18 = 262144 rows per chunk.
+        .chunk_size_log2(18)
+        .precompiles(RuntimeLibs::new().with_arith())
+        .build();
+
+    // Fast dry run to test execution.
+    session.run();
+
+    // Uncomment to compute the proof.
+    // session.prove();
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -203,6 +203,14 @@ mod traits;
 mod uint;
 mod wrapping;
 
+/// Powdr accelerator support for use in zkVM guest.
+///
+/// Provides a direct interface for calling big integer arithmetic accelerator with U256 and U128
+/// types. You may prefer to use the Residue types in crypto_bigint::modular, which have
+/// automatic accelerator support when used with a 256-bit modulus.
+#[cfg(all(target_os = "zkvm", target_arch = "riscv32"))]
+pub mod powdr;
+
 /// Import prelude for this crate: includes important traits.
 pub mod prelude {
     #[cfg(feature = "hybrid-array")]

--- a/src/modular/boxed_monty_form.rs
+++ b/src/modular/boxed_monty_form.rs
@@ -17,6 +17,10 @@ use crate::{BoxedUint, Limb, Monty, Odd, Word};
 use alloc::sync::Arc;
 use subtle::Choice;
 
+#[cfg(all(target_os = "zkvm", target_arch = "riscv32"))]
+use crate::powdr;
+use crate::U256;
+
 #[cfg(feature = "zeroize")]
 use zeroize::Zeroize;
 
@@ -148,6 +152,39 @@ impl BoxedMontyForm {
     /// Instantiates a new [`BoxedMontyForm`] that represents an integer modulo the provided params.
     pub fn new(mut integer: BoxedUint, params: BoxedMontyParams) -> Self {
         debug_assert_eq!(integer.bits_precision(), params.bits_precision());
+
+        #[cfg(all(target_os = "zkvm", target_arch = "riscv32"))]
+        if integer.nlimbs() == powdr::BIGINT_WIDTH_WORDS && params.modulus.nlimbs() == powdr::BIGINT_WIDTH_WORDS {
+            // When working with U256 in the Powdr zkVM, leave the value in standard form.
+            // Ensure that the input is reduced by passing it though a modmul by one.
+            return Self {
+                montgomery_form: powdr::modmul_boxed_uint_256(
+                    &integer,
+                    // &BoxedUint::one(),
+                    &BoxedUint::from(U256::ONE),
+                    &params.modulus.clone().get(),
+                ),
+                params: params.into(),
+            };
+            // panic!();
+            // convert_to_montgomery(&mut integer, &params);
+
+            // #[allow(clippy::useless_conversion)]
+            // return Self {
+            //     montgomery_form: integer,
+            //     params: params.into(),
+            // }
+        } else {
+            convert_to_montgomery(&mut integer, &params);
+
+            #[allow(clippy::useless_conversion)]
+            return Self {
+                montgomery_form: integer,
+                params: params.into(),
+            }
+            // panic!();
+        }
+
         convert_to_montgomery(&mut integer, &params);
 
         #[allow(clippy::useless_conversion)]
@@ -160,6 +197,21 @@ impl BoxedMontyForm {
     /// Instantiates a new [`BoxedMontyForm`] that represents an integer modulo the provided params.
     pub fn new_with_arc(mut integer: BoxedUint, params: Arc<BoxedMontyParams>) -> Self {
         debug_assert_eq!(integer.bits_precision(), params.bits_precision());
+        
+        #[cfg(all(target_os = "zkvm", target_arch = "riscv32"))]
+        if integer.limbs.len() == powdr::BIGINT_WIDTH_WORDS {
+            // When working with U256 in the Powdr zkVM, leave the value in standard form.
+            // Ensure that the input is reduced by passing it though a modmul by one.
+            return Self {
+                montgomery_form: powdr::modmul_boxed_uint_256(
+                    &integer,
+                    &BoxedUint::from(U256::ONE),
+                    &params.modulus,
+                ),
+                params,
+            };
+        }
+        
         convert_to_montgomery(&mut integer, &params);
         Self {
             montgomery_form: integer,
@@ -174,6 +226,12 @@ impl BoxedMontyForm {
 
     /// Retrieves the integer currently encoded in this [`BoxedMontyForm`], guaranteed to be reduced.
     pub fn retrieve(&self) -> BoxedUint {
+        #[cfg(all(target_os = "zkvm", target_arch = "riscv32"))]
+        if self.montgomery_form.limbs.len() == powdr::BIGINT_WIDTH_WORDS {
+            // In the Powdr zkVM 256-bit residues are represented in standard form.
+            return self.montgomery_form.clone();
+        }
+
         let mut montgomery_form = self.montgomery_form.widen(self.bits_precision() * 2);
 
         let ret = montgomery_reduction_boxed(
@@ -199,6 +257,20 @@ impl BoxedMontyForm {
 
     /// Instantiates a new `ConstMontyForm` that represents 1.
     pub fn one(params: BoxedMontyParams) -> Self {
+        #[cfg(all(target_os = "zkvm", target_arch = "riscv32"))]
+        if params.one.limbs.len() == powdr::BIGINT_WIDTH_WORDS {
+            Self {
+                montgomery_form: BoxedUint::one(),
+                params: params.into(),
+            }
+        } else {
+            Self {
+                montgomery_form: params.one.clone(),
+                params: params.into(),
+            }
+        }
+
+        #[cfg(not(all(target_os = "zkvm", target_arch = "riscv32")))]
         Self {
             montgomery_form: params.one.clone(),
             params: params.into(),

--- a/src/modular/boxed_monty_form/mul.rs
+++ b/src/modular/boxed_monty_form/mul.rs
@@ -19,10 +19,24 @@ use subtle::{ConditionallySelectable, ConstantTimeLess};
 #[cfg(feature = "zeroize")]
 use zeroize::Zeroize;
 
+#[cfg(all(target_os = "zkvm", target_arch = "riscv32"))]
+use crate::powdr;
+
 impl BoxedMontyForm {
     /// Multiplies by `rhs`.
     pub fn mul(&self, rhs: &Self) -> Self {
         debug_assert_eq!(&self.params, &rhs.params);
+
+        #[cfg(all(target_os = "zkvm", target_arch = "riscv32"))]
+        return Self {
+            montgomery_form: powdr::modmul_boxed_uint_256(
+                &self.montgomery_form,
+                &rhs.montgomery_form,
+                &self.params.modulus.clone().get(),
+            ),
+            params: self.params.clone(),
+        };
+
         let montgomery_form = MontyMultiplier::from(self.params.borrow())
             .mul(&self.montgomery_form, &rhs.montgomery_form);
 

--- a/src/modular/const_monty_form.rs
+++ b/src/modular/const_monty_form.rs
@@ -14,6 +14,9 @@ use crate::{ConstZero, Limb, Odd, PrecomputeInverter, Uint};
 use core::{fmt::Debug, marker::PhantomData};
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq};
 
+#[cfg(all(target_os = "zkvm", target_arch = "riscv32"))]
+use crate::powdr;
+
 #[cfg(feature = "rand_core")]
 use crate::{rand_core::RngCore, Random, RandomMod};
 
@@ -92,6 +95,23 @@ impl<MOD: ConstMontyParams<LIMBS>, const LIMBS: usize> ConstMontyForm<MOD, LIMBS
     };
 
     /// The representation of 1 mod `MOD`.
+    #[cfg(all(target_os = "zkvm", target_arch = "riscv32"))]
+    pub const ONE: Self = {
+        if LIMBS == powdr::BIGINT_WIDTH_WORDS {
+            Self {
+                montgomery_form: Uint::<LIMBS>::ONE,
+                phantom: PhantomData,
+            }
+        } else {
+            Self {
+                montgomery_form: MOD::ONE,
+                phantom: PhantomData,
+            }
+        }
+    };
+
+    /// The representation of 1 mod `MOD`.
+    #[cfg(not(all(target_os = "zkvm", target_arch = "riscv32")))]
     pub const ONE: Self = Self {
         montgomery_form: MOD::ONE,
         phantom: PhantomData,
@@ -99,7 +119,21 @@ impl<MOD: ConstMontyParams<LIMBS>, const LIMBS: usize> ConstMontyForm<MOD, LIMBS
 
     /// Internal helper function to convert to Montgomery form;
     /// this lets us cleanly wrap the constructors.
-    const fn from_integer(integer: &Uint<LIMBS>) -> Self {
+    fn from_integer(integer: &Uint<LIMBS>) -> Self {
+        #[cfg(all(target_os = "zkvm", target_arch = "riscv32"))]
+        if LIMBS == powdr::BIGINT_WIDTH_WORDS {
+            // When working with U256 in the Powdr zkVM, leave the value in standard form.
+            // Ensure that the input is reduced by passing it though a modmul by one.
+            return Self {
+                montgomery_form: powdr::modmul_uint_256(
+                    &integer,
+                    &Uint::<LIMBS>::ONE,
+                    &MOD::MODULUS,
+                ),
+                phantom: PhantomData,
+            };
+        }
+
         let product = integer.split_mul(&MOD::R2);
         let montgomery_form =
             montgomery_reduction::<LIMBS>(&product, &MOD::MODULUS, MOD::MOD_NEG_INV);
@@ -111,12 +145,18 @@ impl<MOD: ConstMontyParams<LIMBS>, const LIMBS: usize> ConstMontyForm<MOD, LIMBS
     }
 
     /// Instantiates a new [`ConstMontyForm`] that represents this `integer` mod `MOD`.
-    pub const fn new(integer: &Uint<LIMBS>) -> Self {
+    pub fn new(integer: &Uint<LIMBS>) -> Self {
         Self::from_integer(integer)
     }
 
     /// Retrieves the integer currently encoded in this [`ConstMontyForm`], guaranteed to be reduced.
-    pub const fn retrieve(&self) -> Uint<LIMBS> {
+    pub fn retrieve(&self) -> Uint<LIMBS> {
+        #[cfg(all(target_os = "zkvm", target_arch = "riscv32"))]
+        if LIMBS == powdr::BIGINT_WIDTH_WORDS {
+            // In the Powdr zkVM 256-bit residues are represented in standard form.
+            return self.montgomery_form;
+        }
+
         montgomery_reduction::<LIMBS>(
             &(self.montgomery_form, Uint::ZERO),
             &MOD::MODULUS,
@@ -229,8 +269,28 @@ where
     where
         D: Deserializer<'de>,
     {
+        #[cfg(all(target_os = "zkvm", target_arch = "riscv32"))]
+        let r_inv: Uint<{ LIMBS }> = ConstMontyForm::<MOD, LIMBS>::ONE.inv().unwrap();
+        // let inverter = MOD::precompute_inverter();
+        // let r_inv = inverter.invert(&MOD::ONE).unwrap();
+        // let x_mod = const_monty_form!(x, Modulus);
+        // let inverter = Modulus::precompute_inverter();
+        // let inv = inverter.invert(&x_mod).unwrap();
+        // let res = x_mod * inv;
+        // let r_inv: Uint<{ LIMBS }> = MOD::ONE.inv_odd_mod(&MOD::MODULUS).0;
+
         Uint::<LIMBS>::deserialize(deserializer).and_then(|montgomery_form| {
             if montgomery_form < MOD::MODULUS.0 {
+                #[cfg(all(target_os = "zkvm", target_arch = "riscv32"))]
+                if LIMBS == powdr::BIGINT_WIDTH_WORDS {
+                    // In the Powdr zkVM 256-bit residues are represented in standard form.
+                    // To ensure this is interoperable with the host, convert to standard form.
+                    let value = powdr::modmul_uint_256(&montgomery_form, &r_inv, &MOD::MODULUS);
+                    return Ok(Self {
+                        montgomery_form: value,
+                        phantom: PhantomData,
+                    });
+                }
                 Ok(Self {
                     montgomery_form,
                     phantom: PhantomData,
@@ -252,6 +312,36 @@ where
     where
         S: Serializer,
     {
+        #[cfg(all(target_os = "zkvm", target_arch = "riscv32"))]
+        if LIMBS == powdr::BIGINT_WIDTH_WORDS {
+            // In the Powdr zkVM 256-bit residues are represented in standard form.
+            // To ensure this is interoperable with the host, convert to Montgomery form.
+            let value = powdr::modmul_uint_256(&self.montgomery_form, &MOD::ONE, &MOD::MODULUS);
+            return value.serialize(serializer);
+        }
+
         self.montgomery_form.serialize(serializer)
+    }
+}
+
+#[cfg(all(test, feature = "serde"))]
+mod tests {
+    use crate::{const_residue, impl_modulus, modular::constant_mod::ResidueParams, U256};
+
+    impl_modulus!(
+        Modulus,
+        U256,
+        "9CC24C5DF431A864188AB905AC751B727C9447A8E99E6366E1AD78A21E8D882B"
+    );
+
+    #[test]
+    fn serde_roundtrip() {
+        let value_uint = U256::from(105u64);
+        let value = const_residue!(value_uint, Modulus);
+
+        let value_encoded = bincode::serialize(&value).unwrap();
+        let value_decoded = bincode::deserialize(&value_encoded).unwrap();
+
+        assert_eq!(value, value_decoded);
     }
 }

--- a/src/modular/const_monty_form/inv.rs
+++ b/src/modular/const_monty_form/inv.rs
@@ -7,6 +7,9 @@ use crate::{
 use core::{fmt, marker::PhantomData};
 use subtle::CtOption;
 
+#[cfg(all(target_os = "zkvm", target_arch = "riscv32"))]
+use crate::powdr;
+
 impl<MOD: ConstMontyParams<SAT_LIMBS>, const SAT_LIMBS: usize, const UNSAT_LIMBS: usize>
     ConstMontyForm<MOD, SAT_LIMBS>
 where
@@ -20,10 +23,22 @@ where
     ///
     /// If the number was invertible, the second element of the tuple is the truthy value,
     /// otherwise it is the falsy value (in which case the first element's value is unspecified).
-    pub const fn inv(&self) -> ConstCtOption<Self> {
-        let inverter =
-            <Odd<Uint<SAT_LIMBS>> as PrecomputeInverter>::Inverter::new(&MOD::MODULUS, &MOD::R2);
-
+    pub fn inv(&self) -> ConstCtOption<Self> {
+        let inverter = {
+            #[cfg(all(target_os = "zkvm", target_arch = "riscv32"))]
+            {
+                if MOD::LIMBS == powdr::BIGINT_WIDTH_WORDS {
+                    <Odd<Uint<SAT_LIMBS>> as PrecomputeInverter>::Inverter::new(&MOD::MODULUS, &Uint::<SAT_LIMBS>::ONE)
+                } else {
+                    <Odd<Uint<SAT_LIMBS>> as PrecomputeInverter>::Inverter::new(&MOD::MODULUS, &MOD::R2)
+                }
+            }
+            #[cfg(not(all(target_os = "zkvm", target_arch = "riscv32")))]
+            {
+                <Odd<Uint<SAT_LIMBS>> as PrecomputeInverter>::Inverter::new(&MOD::MODULUS, &MOD::R2)
+            }
+        };
+        
         let maybe_inverse = inverter.inv(&self.montgomery_form);
         let (inverse, inverse_is_some) = maybe_inverse.components_ref();
 
@@ -43,9 +58,21 @@ where
     ///
     /// This version is variable-time with respect to the value of `self`, but constant-time with
     /// respect to `MOD`.
-    pub const fn inv_vartime(&self) -> ConstCtOption<Self> {
-        let inverter =
-            <Odd<Uint<SAT_LIMBS>> as PrecomputeInverter>::Inverter::new(&MOD::MODULUS, &MOD::R2);
+    pub fn inv_vartime(&self) -> ConstCtOption<Self> {
+        let inverter = {
+            #[cfg(all(target_os = "zkvm", target_arch = "riscv32"))]
+            {
+                if MOD::LIMBS == powdr::BIGINT_WIDTH_WORDS {
+                    <Odd<Uint<SAT_LIMBS>> as PrecomputeInverter>::Inverter::new(&MOD::MODULUS, &Uint::<SAT_LIMBS>::ONE)
+                } else {
+                    <Odd<Uint<SAT_LIMBS>> as PrecomputeInverter>::Inverter::new(&MOD::MODULUS, &MOD::R2)
+                }
+            }
+            #[cfg(not(all(target_os = "zkvm", target_arch = "riscv32")))]
+            {
+                <Odd<Uint<SAT_LIMBS>> as PrecomputeInverter>::Inverter::new(&MOD::MODULUS, &MOD::R2)
+            }
+        };
 
         let maybe_inverse = inverter.inv_vartime(&self.montgomery_form);
         let (inverse, inverse_is_some) = maybe_inverse.components_ref();

--- a/src/modular/const_monty_form/mul.rs
+++ b/src/modular/const_monty_form/mul.rs
@@ -14,7 +14,7 @@ use super::{ConstMontyForm, ConstMontyParams};
 
 impl<MOD: ConstMontyParams<LIMBS>, const LIMBS: usize> ConstMontyForm<MOD, LIMBS> {
     /// Multiplies by `rhs`.
-    pub const fn mul(&self, rhs: &Self) -> Self {
+    pub fn mul(&self, rhs: &Self) -> Self {
         Self {
             montgomery_form: mul_montgomery_form(
                 &self.montgomery_form,
@@ -27,7 +27,7 @@ impl<MOD: ConstMontyParams<LIMBS>, const LIMBS: usize> ConstMontyForm<MOD, LIMBS
     }
 
     /// Computes the (reduced) square.
-    pub const fn square(&self) -> Self {
+    pub fn square(&self) -> Self {
         Self {
             montgomery_form: square_montgomery_form(
                 &self.montgomery_form,

--- a/src/modular/const_monty_form/pow.rs
+++ b/src/modular/const_monty_form/pow.rs
@@ -11,7 +11,7 @@ use {crate::modular::pow::multi_exponentiate_montgomery_form_slice, alloc::vec::
 
 impl<MOD: ConstMontyParams<LIMBS>, const LIMBS: usize> ConstMontyForm<MOD, LIMBS> {
     /// Raises to the `exponent` power.
-    pub const fn pow<const RHS_LIMBS: usize>(
+    pub fn pow<const RHS_LIMBS: usize>(
         &self,
         exponent: &Uint<RHS_LIMBS>,
     ) -> ConstMontyForm<MOD, LIMBS> {
@@ -23,7 +23,7 @@ impl<MOD: ConstMontyParams<LIMBS>, const LIMBS: usize> ConstMontyForm<MOD, LIMBS
     /// to take into account for the exponent.
     ///
     /// NOTE: `exponent_bits` may be leaked in the time pattern.
-    pub const fn pow_bounded_exp<const RHS_LIMBS: usize>(
+    pub fn pow_bounded_exp<const RHS_LIMBS: usize>(
         &self,
         exponent: &Uint<RHS_LIMBS>,
         exponent_bits: u32,

--- a/src/modular/monty_form/inv.rs
+++ b/src/modular/monty_form/inv.rs
@@ -8,6 +8,9 @@ use crate::{
 use core::fmt;
 use subtle::CtOption;
 
+#[cfg(all(target_os = "zkvm", target_arch = "riscv32"))]
+use crate::powdr;
+
 impl<const SAT_LIMBS: usize, const UNSAT_LIMBS: usize> MontyForm<SAT_LIMBS>
 where
     Odd<Uint<SAT_LIMBS>>: PrecomputeInverter<
@@ -20,11 +23,32 @@ where
     ///
     /// If the number was invertible, the second element of the tuple is the truthy value,
     /// otherwise it is the falsy value (in which case the first element's value is unspecified).
-    pub const fn inv(&self) -> ConstCtOption<Self> {
-        let inverter = <Odd<Uint<SAT_LIMBS>> as PrecomputeInverter>::Inverter::new(
-            &self.params.modulus,
-            &self.params.r2,
-        );
+    pub fn inv(&self) -> ConstCtOption<Self> {
+        let inverter = {
+            #[cfg(all(target_os = "zkvm", target_arch = "riscv32"))]
+            {
+                // U256 in Powdr zkVM are left in standard form instead of Montgomery form.
+                // Therefore, inversion adjuster is 1 instead of R^2.
+                if SAT_LIMBS == powdr::BIGINT_WIDTH_WORDS {
+                    <Odd<Uint<SAT_LIMBS>> as PrecomputeInverter>::Inverter::new(
+                        &self.params.modulus,
+                        &Uint::<SAT_LIMBS>::ONE,
+                    )
+                } else {
+                    <Odd<Uint<SAT_LIMBS>> as PrecomputeInverter>::Inverter::new(
+                        &self.params.modulus,
+                        &self.params.r2,
+                    )
+                }
+            }
+            #[cfg(not(all(target_os = "zkvm", target_arch = "riscv32")))]
+            {
+                <Odd<Uint<SAT_LIMBS>> as PrecomputeInverter>::Inverter::new(
+                    &self.params.modulus,
+                    &self.params.r2,
+                )
+            }
+        };
 
         let maybe_inverse = inverter.inv(&self.montgomery_form);
         let (inverse, inverse_is_some) = maybe_inverse.components_ref();
@@ -45,7 +69,7 @@ where
     ///
     /// This version is variable-time with respect to the value of `self`, but constant-time with
     /// respect to `self`'s `params`.
-    pub const fn inv_vartime(&self) -> ConstCtOption<Self> {
+    pub fn inv_vartime(&self) -> ConstCtOption<Self> {
         let inverter = <Odd<Uint<SAT_LIMBS>> as PrecomputeInverter>::Inverter::new(
             &self.params.modulus,
             &self.params.r2,

--- a/src/modular/monty_form/mul.rs
+++ b/src/modular/monty_form/mul.rs
@@ -9,7 +9,7 @@ use core::ops::{Mul, MulAssign};
 
 impl<const LIMBS: usize> MontyForm<LIMBS> {
     /// Multiplies by `rhs`.
-    pub const fn mul(&self, rhs: &Self) -> Self {
+    pub fn mul(&self, rhs: &Self) -> Self {
         Self {
             montgomery_form: mul_montgomery_form(
                 &self.montgomery_form,
@@ -22,7 +22,7 @@ impl<const LIMBS: usize> MontyForm<LIMBS> {
     }
 
     /// Computes the (reduced) square.
-    pub const fn square(&self) -> Self {
+    pub fn square(&self) -> Self {
         Self {
             montgomery_form: square_montgomery_form(
                 &self.montgomery_form,

--- a/src/modular/monty_form/pow.rs
+++ b/src/modular/monty_form/pow.rs
@@ -11,7 +11,7 @@ use {crate::modular::pow::multi_exponentiate_montgomery_form_slice, alloc::vec::
 
 impl<const LIMBS: usize> MontyForm<LIMBS> {
     /// Raises to the `exponent` power.
-    pub const fn pow<const RHS_LIMBS: usize>(
+    pub fn pow<const RHS_LIMBS: usize>(
         &self,
         exponent: &Uint<RHS_LIMBS>,
     ) -> MontyForm<LIMBS> {
@@ -23,7 +23,7 @@ impl<const LIMBS: usize> MontyForm<LIMBS> {
     /// to take into account for the exponent.
     ///
     /// NOTE: `exponent_bits` may be leaked in the time pattern.
-    pub const fn pow_bounded_exp<const RHS_LIMBS: usize>(
+    pub fn pow_bounded_exp<const RHS_LIMBS: usize>(
         &self,
         exponent: &Uint<RHS_LIMBS>,
         exponent_bits: u32,

--- a/src/modular/mul.rs
+++ b/src/modular/mul.rs
@@ -1,21 +1,34 @@
 use super::reduction::montgomery_reduction;
 use crate::{Limb, Odd, Uint};
 
-pub(crate) const fn mul_montgomery_form<const LIMBS: usize>(
+#[cfg(all(target_os = "zkvm", target_arch = "riscv32"))]
+use crate::powdr;
+
+pub(crate) fn mul_montgomery_form<const LIMBS: usize>(
     a: &Uint<LIMBS>,
     b: &Uint<LIMBS>,
     modulus: &Odd<Uint<LIMBS>>,
     mod_neg_inv: Limb,
 ) -> Uint<LIMBS> {
+    #[cfg(all(target_os = "zkvm", target_arch = "riscv32"))]
+    if LIMBS == powdr::BIGINT_WIDTH_WORDS {
+        return powdr::modmul_uint_256(a, b, modulus);
+    }
+
     let product = a.split_mul(b);
     montgomery_reduction::<LIMBS>(&product, modulus, mod_neg_inv)
 }
 
-pub(crate) const fn square_montgomery_form<const LIMBS: usize>(
+pub(crate) fn square_montgomery_form<const LIMBS: usize>(
     a: &Uint<LIMBS>,
     modulus: &Odd<Uint<LIMBS>>,
     mod_neg_inv: Limb,
 ) -> Uint<LIMBS> {
+    #[cfg(all(target_os = "zkvm", target_arch = "riscv32"))]
+    if LIMBS == powdr::BIGINT_WIDTH_WORDS {
+        return powdr::modmul_uint_256(a, a, modulus);
+    }
+
     let product = a.square_wide();
     montgomery_reduction::<LIMBS>(&product, modulus, mod_neg_inv)
 }

--- a/src/powdr.rs
+++ b/src/powdr.rs
@@ -1,0 +1,142 @@
+#![allow(unsafe_code)]
+use powdr_riscv_runtime::arith::{modmul_256_u8_le, modmul_256_u32_le};
+// use zeroize::Zeroize;
+use crate::{Encoding, Uint, BoxedUint, U256};
+use subtle::ConstantTimeLess;
+
+/// Powdr supports BigInt operations with a width of 256-bits as 8x32-bit words.
+pub(crate) const BIGINT_WIDTH_WORDS: usize = 8;
+
+/// Modular multiplication of two 256-bit Uint values using the Powdr accelerator.
+/// Returns the fully reduced and normalized modular multiplication result.
+///
+/// NOTE: This method takes generic Uint values, but asserts that the input is 256 bits. It is
+/// provided because the main places we want to patch in multiplication use the generic Uint type,
+/// and specialization is not a stable Rust feature. When inlined, the assert should be removed.
+#[inline(always)]
+pub fn modmul_uint_256<const LIMBS: usize>(
+    a: &Uint<LIMBS>,
+    b: &Uint<LIMBS>,
+    modulus: &Uint<LIMBS>,
+) -> Uint<LIMBS> {
+    // Assert that we are working with 8x32 Uints.
+    assert!(LIMBS == BIGINT_WIDTH_WORDS);
+
+    // Convert to arrays of size 8 using slices
+    let a_words: [u32; 8] = a.as_words ()[..8].try_into().expect("Array size mismatch");
+    let b_words: [u32; 8] = b.to_words()[..8].try_into().expect("Array size mismatch");
+    let modulus_words: [u32; 8] = modulus.to_words()[..8].try_into().expect("Array size mismatch");
+
+    // Perform modular multiplication
+    let result_words = unsafe { modmul_256_u32_le(a_words, b_words, modulus_words) };
+
+    // Convert the result back to Uint<LIMBS>
+    let mut result_array = [0u32; LIMBS];
+    result_array[..8].copy_from_slice(&result_words);
+
+  
+    // Convert back to Uint<LIMBS>
+    let result = Uint::<LIMBS>::from_words(result_array);
+
+    // Assert that the Prover returned the canonical representation of the result, i.e. that it
+    // is fully reduced and has no multiples of the modulus included.
+    // NOTE: On a cooperating prover, this check will always evaluate to false, and therefore
+    // will have timing invariant with any secrets. If the prover is faulty, this check may
+    // leak secret information through timing, however this is out of scope since a faulty
+    // cannot be relied upon for the privacy of the inputs.
+    assert!(bool::from(result.ct_lt(&modulus)));
+    result
+}
+
+/// Modular multiplication of two 256-bit Uint values using the Powdr accelerator.
+/// Returns the fully reduced and normalized modular multiplication result.
+///
+/// NOTE: This method takes generic Uint values, but asserts that the input is 256 bits. It is
+/// provided because the main places we want to patch in multiplication use the generic Uint type,
+/// and specialization is not a stable Rust feature. When inlined, the assert should be removed.
+#[inline(always)]
+pub fn modmul_boxed_uint_256(
+    a: &BoxedUint,
+    b: &BoxedUint,
+    modulus: &BoxedUint,
+) -> BoxedUint {
+    // Assert that we are working with 8x32 Uints.
+    assert!(a.limbs.len() == BIGINT_WIDTH_WORDS);
+    assert!(b.limbs.len() == BIGINT_WIDTH_WORDS);
+    assert!(modulus.limbs.len() == BIGINT_WIDTH_WORDS);
+
+    // Convert to arrays of size 8 using slices
+    let a_words: [u32; 8] = a.to_words()[..8].try_into().expect("Array size mismatch");
+    let b_words: [u32; 8] = b.to_words()[..8].try_into().expect("Array size mismatch");
+    let modulus_words: [u32; 8] = modulus.to_words()[..8].try_into().expect("Array size mismatch");
+
+    // Perform modular multiplication
+    let result_words = unsafe { modmul_256_u32_le(a_words, b_words, modulus_words) };
+  
+    // Convert back to Uint<LIMBS>
+    let result = BoxedUint::from_words(result_words);
+
+    // Assert that the Prover returned the canonical representation of the result, i.e. that it
+    // is fully reduced and has no multiples of the modulus included.
+    // NOTE: On a cooperating prover, this check will always evaluate to false, and therefore
+    // will have timing invariant with any secrets. If the prover is faulty, this check may
+    // leak secret information through timing, however this is out of scope since a faulty
+    // cannot be relied upon for the privacy of the inputs.
+    assert!(bool::from(result.ct_lt(&modulus)));
+    result
+}
+
+/// Modular multiplication of two 256-bit Uint values using the Powdr accelerator.
+/// Returns a result in the equivelence class of integers under the modulus, but the result is not
+/// guarenteed to be fully reduced. In particular, it may include any number of multiples of the
+/// modulus.
+#[inline(always)]
+pub fn modmul_u256_denormalized(a: &U256, b: &U256, modulus: &U256) -> U256 {
+    U256::from_le_bytes(unsafe {
+      modmul_256_u8_le(
+            a.to_le_bytes(),
+            b.to_le_bytes(),
+            modulus.to_le_bytes(),
+        )
+    })
+}
+
+/// Modular multiplication of two 256-bit Uint values using the Powdr accelerator.
+/// Returns the fully reduced and normalized modular multiplication result.
+#[inline(always)]
+pub fn modmul_u256(a: &U256, b: &U256, modulus: &U256) -> U256 {
+    let result = modmul_u256_denormalized(a, b, modulus);
+    // Assert that the Prover returned the canonical representation of the result, i.e. that it
+    // is fully reduced and has no multiples of the modulus included.
+    // NOTE: On a cooperating prover, this check will always evaluate to false, and therefore
+    // will have timing invariant with any secrets. If the prover is faulty, this check may
+    // leak secret information through timing, however this is out of scope since a faulty
+    // cannot be relied upon for the privacy of the inputs.
+    assert!(bool::from(result.ct_lt(&modulus)));
+    result
+}
+
+// fn convert_le_u64_to_u32<const LIMBS: usize>(input: [u64; LIMBS]) -> [u32; LIMBS * 2] {
+//   let mut output = [0u32; LIMBS * 2];
+
+//   for (i, &val) in input.iter().enumerate() {
+//       // Extract the lower 32 bits and the upper 32 bits of the u64 value
+//       output[i * 2] = (val & 0xFFFF_FFFF) as u32;      // Lower 32 bits
+//       output[i * 2 + 1] = (val >> 32) as u32;          // Upper 32 bits
+//   }
+
+//   output
+// }
+
+// fn convert_le_u32_to_u64<const LIMBS: usize>(input: [u32; LIMBS * 2]) -> [u64; LIMBS] {
+//   let mut output = [0u64; LIMBS];
+
+//   for i in 0..LIMBS {
+//       // Combine two u32 values into a single u64 value
+//       let low = input[i * 2] as u64;
+//       let high = (input[i * 2 + 1] as u64) << 32;
+//       output[i] = low | high;
+//   }
+
+//   output
+// }

--- a/src/uint/boxed/inv_mod.rs
+++ b/src/uint/boxed/inv_mod.rs
@@ -6,6 +6,9 @@ use crate::{
 };
 use subtle::{Choice, ConstantTimeEq, ConstantTimeLess, CtOption};
 
+#[cfg(all(target_os = "zkvm", target_arch = "riscv32"))]
+use crate::{U256, powdr};
+
 impl BoxedUint {
     /// Computes the multiplicative inverse of `self` mod `modulus`, where `modulus` is odd.
     pub fn inv_odd_mod(&self, modulus: &Odd<Self>) -> CtOption<Self> {
@@ -98,6 +101,15 @@ impl PrecomputeInverter for Odd<BoxedUint> {
 /// Precompute a Bernstein-Yang inverter using `self` as the modulus.
 impl PrecomputeInverterWithAdjuster<BoxedUint> for Odd<BoxedUint> {
     fn precompute_inverter_with_adjuster(&self, adjuster: &BoxedUint) -> BoxedSafeGcdInverter {
+        #[cfg(all(target_os = "zkvm", target_arch = "riscv32"))]
+        // U256 in Powdr zkVM are left in standard form instead of Montgomery form.
+        // Therefore, inversion adjuster is 1 instead of R^2.
+        if adjuster.nlimbs() == powdr::BIGINT_WIDTH_WORDS {
+            return BoxedSafeGcdInverter::new(self, &BoxedUint::from(U256::ONE));
+        } else {
+            return BoxedSafeGcdInverter::new(self, adjuster);
+        }
+
         BoxedSafeGcdInverter::new(self, adjuster)
     }
 }

--- a/src/uint/boxed/mul_mod.rs
+++ b/src/uint/boxed/mul_mod.rs
@@ -3,8 +3,11 @@
 use crate::{
     div_limb::mul_rem,
     modular::{BoxedMontyForm, BoxedMontyParams},
-    BoxedUint, Limb, MulMod, NonZero, Odd, WideWord, Word,
+    BoxedUint, Limb, MulMod, NonZero, Odd, WideWord, Word, U256
 };
+
+#[cfg(all(target_os = "zkvm", target_arch = "riscv32"))]
+use crate::powdr;
 
 impl BoxedUint {
     /// Computes `self * rhs mod p` for odd `p`.
@@ -48,6 +51,15 @@ impl BoxedUint {
                 NonZero::<Limb>::new_unwrap(Limb(Word::MIN.wrapping_sub(c.0))),
             );
             return Self::from(reduced);
+        }
+
+        #[cfg(all(target_os = "zkvm", target_arch = "riscv32"))]
+        if self.nlimbs() == powdr::BIGINT_WIDTH_WORDS {
+            return powdr::modmul_boxed_uint_256(
+                &self,
+                &rhs,
+                &BoxedUint::from(U256::ZERO).wrapping_sub(&c.into()),
+            );
         }
 
         let product = self.mul(rhs);

--- a/src/uint/mul_mod.rs
+++ b/src/uint/mul_mod.rs
@@ -6,6 +6,9 @@ use crate::{
     Concat, Limb, MulMod, NonZero, Split, Uint, WideWord, Word,
 };
 
+#[cfg(all(target_os = "zkvm", target_arch = "riscv32"))]
+use crate::powdr;
+
 impl<const LIMBS: usize> Uint<LIMBS> {
     /// Computes `self * rhs mod p` for odd `p`.
     ///
@@ -41,7 +44,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     /// For the modulus reduction, this function implements Algorithm 14.47 from
     /// the "Handbook of Applied Cryptography", by A. Menezes, P. van Oorschot,
     /// and S. Vanstone, CRC Press, 1996.
-    pub const fn mul_mod_special(&self, rhs: &Self, c: Limb) -> Self {
+    pub fn mul_mod_special(&self, rhs: &Self, c: Limb) -> Self {
         // We implicitly assume `LIMBS > 0`, because `Uint<0>` doesn't compile.
         // Still the case `LIMBS == 1` needs special handling.
         if LIMBS == 1 {
@@ -52,6 +55,16 @@ impl<const LIMBS: usize> Uint<LIMBS> {
             );
             return Self::from_word(reduced.0);
         }
+
+        #[cfg(all(target_os = "zkvm", target_arch = "riscv32"))]
+        if LIMBS == powdr::BIGINT_WIDTH_WORDS {
+            return powdr::modmul_uint_256(
+                &self,
+                rhs,
+                &Uint::<LIMBS>::ZERO.wrapping_sub(&c.into()),
+            );
+        }
+        
 
         let (lo, hi) = self.split_mul(rhs);
 


### PR DESCRIPTION
This is NOT a PR but just to show the diff and store the following notes on how this branch is created an tested.

**Background**
This is a fork of the latest main of Rust-Crypto/crypto-bigint as of 1/15/2025. Risc0 created another fork of a much earlier (and outdated) main of Rust-Crypto/crypto-bigint that we referenced.

**Why the patch**
The gist of the patch is to NOT use Montgomery form representations of bigints. Montgomery form is commonly used to speed up modular multiplication and inversion algorithms. However, PowdrVM acceleration computes bigint modular multiplication via lower level assembly and no longer requires using Montgomery forms. However, crates that depend on `crypto-bigint` still indirectly uses Montgomery form. Our patch doesn't remove these uses but instead removes the conversion from standard form to Montgomery form and vice versa.

**Extent of the patch**
Functions that need Powdr patch largely mirror what Risc0 patched an earlier version of crypto-bigint: https://github.com/risc0/RustCrypto-crypto-bigint/compare/v0.5.5...v0.5.5-risczero.0. However, our patch and Risc0 patch are not fully comparable, because Rust-Crypto/crypto-bigint has changed a lot since Risc0 last patched it. We've incorporated these changes in our patch.

**RustCrypto/crypto-bigint changes since Risc0 patch**
Most changes involve a complete restructure of the files and types. Montgomery form types became `ConstMontyForm`, `BoxedMontyForm`, and `MontyForm`. These types wrap `Uint` and `BoxedUint` types, which are arbitrary length integers split to 32-bit limbs. The API/algorithms for computing inversions and multiplications have also been updated. Therefore, patching Powdr to the updated crypto-bigint requires understanding these changes.

**Testing coverage**
All powdr patch tests are under `powdr_test` folder, which is a separate Rust crate modified from the PowdrVM boilerplate code. `main.rs` from the guest program contains all unit tests. `cargo run -r` on the host crate should run the test. Unit tests cover all Powdr patched functions except Serde trait implementations. Test vectors are mostly manually generated, with a few directly taken from original tests from `RustCrypto/crypto-bigint`.
